### PR TITLE
Fix pluralize filter and create new ordinalize filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ module.exports = {
 #### pluralize
 
 + Arguments:
-  * `{String} single, [double, triple, ...]`
+  * `{Number} single, [double, triple, ...]`
 
 + Example:
 
@@ -182,7 +182,22 @@ module.exports = {
   ```
 
   ```js
-  {{date}} {{date | pluralize('st','nd','rd','th')}} 
+  {{amount}} {{amount | pluralize('fry', 'fries')}} 
+
+  // 1 => '1 fry'
+  // 2 => '2 fries'
+  // 3 => '3 fries'
+  ```
+
+#### ordinalize
+
++ Arguments:
+  * `{Number}`
+
++ Example:
+
+  ```js
+  {{date | ordinalize}} 
 
   // 1 => '1st'
   // 2 => '2nd'

--- a/src/other/index.js
+++ b/src/other/index.js
@@ -1,7 +1,9 @@
 import currency from './currency'
 import pluralize from './pluralize'
+import ordinalize from './ordinalize'
 
 export {
   currency,
-  pluralize
+  pluralize,
+  ordinalize
 }

--- a/src/other/ordinalize.js
+++ b/src/other/ordinalize.js
@@ -1,0 +1,20 @@
+import util from '../util/index'
+
+var endings = ['th', 'st', 'nd', 'rd']
+
+/**
+ * 42 => '42nd'
+ *
+ * @params
+ *  A single number to be ordinalized.
+ *  Numbers ending in '1' are appended with 'st'.
+ *  Numbers ending in '2' are appended with 'nd'.
+ *  Numbers ending in '3' are appended with 'rd'.
+ *  All other numbers are appended with 'th'.
+ */
+
+function ordinalize (value) {
+  return value + (endings[value % 10] || endings[0])
+}
+
+export default ordinalize

--- a/src/other/pluralize.js
+++ b/src/other/pluralize.js
@@ -16,7 +16,7 @@ import util from '../util/index'
 function pluralize (value) {
   var args = util.toArray(arguments, 1)
   return args.length > 1
-    ? (args[value % 10 - 1] || args[args.length - 1])
+    ? (args[value - 1] || args[args.length - 1])
     : (args[0] + (value === 1 ? '' : 's'))
 }
 

--- a/test/filters.spec.js
+++ b/test/filters.spec.js
@@ -87,12 +87,35 @@ describe('Filters', function() {
     expect(filter(0, arg)).toBe('items')
     expect(filter(1, arg)).toBe('item')
     expect(filter(2, arg)).toBe('items')
+    expect(filter(21, arg)).toBe('items')
+
     // multi args
-    expect(filter(0, 'st', 'nd', 'rd', 'th')).toBe('th')
-    expect(filter(1, 'st', 'nd', 'rd', 'th')).toBe('st')
-    expect(filter(2, 'st', 'nd', 'rd', 'th')).toBe('nd')
-    expect(filter(3, 'st', 'nd', 'rd', 'th')).toBe('rd')
-    expect(filter(4, 'st', 'nd', 'rd', 'th')).toBe('th')
+    expect(filter(0, 'fry', 'fries')).toBe('fries')
+    expect(filter(1, 'fry', 'fries')).toBe('fry')
+    expect(filter(2, 'fry', 'fries')).toBe('fries')
+
+    expect(filter(0, 'first', 'second', 'third', 'nth')).toBe('nth')
+    expect(filter(1, 'first', 'second', 'third', 'nth')).toBe('first')
+    expect(filter(2, 'first', 'second', 'third', 'nth')).toBe('second')
+    expect(filter(3, 'first', 'second', 'third', 'nth')).toBe('third')
+    expect(filter(4, 'first', 'second', 'third', 'nth')).toBe('nth')
+    expect(filter(50, 'first', 'second', 'third', 'nth')).toBe('nth')
+  })
+
+  it('ordinalize', function() {
+    var filter = otherFilters.ordinalize
+
+    expect(filter(0)).toBe('0th')
+    expect(filter(1)).toBe('1st')
+    expect(filter(2)).toBe('2nd')
+    expect(filter(3)).toBe('3rd')
+    expect(filter(4)).toBe('4th')
+
+    expect(filter(230)).toBe('230th')
+    expect(filter(231)).toBe('231st')
+    expect(filter(232)).toBe('232nd')
+    expect(filter(233)).toBe('233rd')
+    expect(filter(234)).toBe('234th')
   })
 
   it('limitBy', function () {


### PR DESCRIPTION
Hey! I noticed that the `pluralize` filter didn't behave the way I expected it to for numbers larger than 10 when providing the word variants. For example:

```js
{{ 21 }}  {{ 21 | pluralize('spy', 'spies') }}
// expected: '21 spies'
// actual: '21 spy'
```

Looking at the README, I saw that the examples showed using the word variants for ordinal numbers, i.e. `1st`, `2nd`, `3rd`, etc., which made sense as a use case, but not so much for a pluralize filter.

This PR makes the word variants version of pluralize work for numbers greater than 10, and adds a new `ordinalize` filter that includes that functionality:

```js
{{ 42 | ordinalize }}
// -> '42nd'
```

Let me know your thoughts. Thanks!